### PR TITLE
Performance improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,36 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "btree-slab"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2b56d3029f075c4fa892428a098425b86cef5c89ae54073137ece416aef13c"
+dependencies = [
+ "cc-traits",
+ "slab",
+ "smallvec",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cc-traits"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "060303ef31ef4a522737e1b1ab68c67916f2a787bb2f4f54f383279adba962b5"
+dependencies = [
+ "slab",
+]
 
 [[package]]
 name = "cfg-if"
@@ -109,6 +135,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 name = "mocd"
 version = "0.1.0"
 dependencies = [
+ "btree-slab",
  "crossbeam",
  "rand",
  "rayon",
@@ -236,6 +263,21 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ rayon = "1.7"           # data parallelism and multi-threading support.
 rustc-hash = { version = "2.1", default-features = true } # a fast hash map implementation.
 serde_json = "1.0.0"    # serializing and deserializing JSON data.
 crossbeam = "0.8"
+btree-slab = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,3 @@ rayon = "1.7"           # data parallelism and multi-threading support.
 rustc-hash = { version = "2.1", default-features = true } # a fast hash map implementation.
 serde_json = "1.0.0"    # serializing and deserializing JSON data.
 crossbeam = "0.8"
-btree-slab = "0.6.1"

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -1,15 +1,10 @@
+use rand::seq::SliceRandom;
+use rand::Rng;
+use rayon::prelude::*;
 use rustc_hash::FxHashMap as HashMap;
 use rustc_hash::FxHashSet as HashSet;
-use rand::Rng;
-use rand::seq::SliceRandom;
-use rayon::prelude::*;
 
-use crate::graph::{
-    Graph,
-    Partition,
-    CommunityId,
-    NodeId
-};
+use crate::graph::{CommunityId, Graph, NodeId, Partition};
 
 #[derive(Debug)]
 #[allow(dead_code)]
@@ -20,7 +15,7 @@ pub struct Metrics {
 }
 
 impl Metrics {
-    pub fn default() -> Self{
+    pub fn default() -> Self {
         return Metrics {
             modularity: 0.0,
             intra: 0.0,
@@ -29,56 +24,68 @@ impl Metrics {
     }
 }
 
-pub fn calculate_objectives(graph: &Graph, partition: &Partition, degrees: HashMap<i32, usize>) -> Metrics {
+pub fn calculate_objectives(
+    graph: &Graph,
+    partition: &Partition,
+    degrees: HashMap<i32, usize>,
+    parallel: bool,
+) -> Metrics {
     let total_edges = graph.edges.len() as f64;
     if total_edges == 0.0 {
         return Metrics::default();
     }
 
     // Build communities from the partition
-    let mut communities: HashMap<CommunityId, HashSet<NodeId>> = HashMap::default();
+    let mut communities: HashMap<CommunityId, Vec<NodeId>> = HashMap::default();
     for (&node, &community) in partition {
         communities
             .entry(community)
-            .or_insert_with(HashSet::default)
-            .insert(node);
+            .or_default()
+            .push(node);
     }
 
     let total_edges_doubled = 2.0 * total_edges;
-    let (intra_sum, inter) = communities.par_iter().fold(
-        || (0.0, 0.0), // Initialize accumulators for each thread
-        |(mut intra_acc, mut inter_acc), (_, community_nodes)| {
-            let mut community_edges = 0.0;
-            let mut community_degree = 0.0;
-    
-            for &node in community_nodes {
-                // Use precomputed degree
-                let node_degree = degrees.get(&node).copied().unwrap_or(0) as f64;
-                community_degree += node_degree;
-    
-                // Iterate through neighbors once
-                for neighbor in graph.neighbors(&node) {
-                    if community_nodes.contains(&neighbor) {
-                        community_edges += 1.0;
-                    }
+    let folder = |(mut intra_acc, mut inter_acc), (_, community_nodes): (&i32, &Vec<i32>)| {
+        let mut community_edges = 0.0;
+        let mut community_degree = 0.0;
+
+        for &node in community_nodes {
+            // Use precomputed degree
+            let node_degree = degrees.get(&node).copied().unwrap_or(0) as f64;
+            community_degree += node_degree;
+
+            // Iterate through neighbors once
+            for neighbor in graph.neighbors(&node) {
+                if community_nodes.binary_search(&neighbor).is_ok() {
+                    community_edges += 1.0;
                 }
             }
-    
-            // Avoid double counting by dividing by 2
-            community_edges /= 2.0;
-            intra_acc += community_edges;
-    
-            // Calculate normalized degree
-            let normalized_degree = community_degree / total_edges_doubled;
-            inter_acc += normalized_degree.powi(2);
-    
-            (intra_acc, inter_acc)
-        },
-    )
-    .reduce(
-        || (0.0, 0.0), // Initialize accumulators for reduction
-        |a, b| (a.0 + b.0, a.1 + b.1), // Combine results from different threads
-    );
+        }
+
+        // Avoid double counting by dividing by 2
+        community_edges /= 2.0;
+        intra_acc += community_edges;
+
+        // Calculate normalized degree
+        let normalized_degree = community_degree / total_edges_doubled;
+        inter_acc += normalized_degree.powi(2);
+
+        (intra_acc, inter_acc)
+    };
+    let (intra_sum, inter) = if parallel {
+        communities
+            .par_iter()
+            .fold(
+                || (0.0, 0.0), // Initialize accumulators for each thread
+                folder,
+            )
+            .reduce(
+                || (0.0, 0.0),                 // Initialize accumulators for reduction
+                |a, b| (a.0 + b.0, a.1 + b.1), // Combine results from different threads
+            )
+    } else {
+        communities.iter().fold((0.0, 0.0), folder)
+    };
 
     let intra = 1.0 - (intra_sum / total_edges);
     let mut modularity = 1.0 - intra - inter;
@@ -93,17 +100,17 @@ pub fn calculate_objectives(graph: &Graph, partition: &Partition, degrees: HashM
 
 fn precompute_degress(graph: &Graph) -> HashMap<i32, usize> {
     let degrees: HashMap<NodeId, usize> = graph
-    .nodes
-    .iter()
-    .map(|&node| (node, graph.neighbors(&node).len()))
-    .collect();
+        .nodes
+        .iter()
+        .map(|&node| (node, graph.neighbors(&node).len()))
+        .collect();
 
     degrees
 }
 
 fn generate_initial_population(graph: &Graph, population_size: usize) -> Vec<Partition> {
     let mut rng = rand::thread_rng();
-    let nodes: Vec<NodeId> = graph.nodes.iter().cloned().collect();
+    let nodes: Vec<NodeId> = graph.nodes.iter().copied().collect();
     let num_nodes = nodes.len();
 
     (0..population_size)
@@ -118,7 +125,7 @@ fn generate_initial_population(graph: &Graph, population_size: usize) -> Vec<Par
 
 fn crossover(parent1: &Partition, parent2: &Partition) -> Partition {
     let mut rng = rand::thread_rng();
-    let keys: Vec<NodeId> = parent1.keys().cloned().collect();
+    let keys: Vec<NodeId> = parent1.keys().copied().collect();
     let len = keys.len();
     let (idx1, idx2) = {
         let mut points = vec![rng.gen_range(0..len), rng.gen_range(0..len)];
@@ -137,10 +144,10 @@ fn crossover(parent1: &Partition, parent2: &Partition) -> Partition {
 
 fn mutate(partition: &mut Partition, graph: &Graph) {
     let mut rng = rand::thread_rng();
-    let nodes: Vec<NodeId> = partition.keys().cloned().collect();
+    let nodes: Vec<NodeId> = partition.keys().copied().collect();
     let node = nodes.choose(&mut rng).unwrap();
     let neighbors = graph.neighbors(node);
-    
+
     if let Some(&neighbor) = neighbors.choose(&mut rng) {
         if let Some(&neighbor_community) = partition.get(&neighbor) {
             partition.insert(*node, neighbor_community);
@@ -148,18 +155,30 @@ fn mutate(partition: &mut Partition, graph: &Graph) {
     }
 }
 
-pub fn genetic_algorithm(graph: &Graph, generations: usize, population_size: usize, debug: bool) -> (Partition, Vec<f64>, f64) {
+pub fn genetic_algorithm(
+    graph: &Graph,
+    generations: usize,
+    population_size: usize,
+    debug: bool,
+    parallel: bool,
+) -> (Partition, Vec<f64>, f64) {
     let mut rng = rand::thread_rng();
     let mut population = generate_initial_population(graph, population_size);
-    let mut best_fitness_history = Vec::with_capacity(generations);    
+    let mut best_fitness_history = Vec::with_capacity(generations);
     let degress = precompute_degress(graph);
 
-
     for generation in 0..generations {
-        let fitnesses: Vec<Metrics> = population
-            .par_iter()
-            .map(|partition| calculate_objectives(graph, partition, degress.clone()))
-            .collect();
+        let fitnesses: Vec<Metrics> = if parallel {
+            population
+                .par_iter()
+                .map(|partition| calculate_objectives(graph, partition, degress.clone(), true))
+                .collect()
+        } else {
+            population
+                .iter()
+                .map(|partition| calculate_objectives(graph, partition, degress.clone(), false))
+                .collect()
+        };
 
         // Record best fitness
         let best_fitness = fitnesses
@@ -170,13 +189,9 @@ pub fn genetic_algorithm(graph: &Graph, generations: usize, population_size: usi
         best_fitness_history.push(best_fitness);
 
         // Selection
-        let mut population_with_fitness: Vec<_> = population
-            .into_iter()
-            .zip(fitnesses)
-            .collect();
-        population_with_fitness.sort_by(|(_, a), (_, b)| {
-            b.modularity.partial_cmp(&a.modularity).unwrap()
-        });
+        let mut population_with_fitness: Vec<_> = population.into_iter().zip(fitnesses).collect();
+        population_with_fitness
+            .sort_by(|(_, a), (_, b)| b.modularity.partial_cmp(&a.modularity).unwrap());
         population = population_with_fitness
             .into_iter()
             .take(population_size / 2)
@@ -194,31 +209,34 @@ pub fn genetic_algorithm(graph: &Graph, generations: usize, population_size: usi
         }
         population = new_population;
 
-        if debug{
-            println!("Generation: {} \t | Best Fitness: {}", 
-            generation, 
-            best_fitness
+        if debug {
+            println!(
+                "Generation: {} \t | Best Fitness: {}",
+                generation, best_fitness
             );
         }
-
     }
 
     // Find best partition
     let best_partition = population
         .into_iter()
         .max_by_key(|partition| {
-            let metrics = calculate_objectives(graph, partition, degress.clone());
+            let metrics = calculate_objectives(graph, partition, degress.clone(), parallel);
             (metrics.modularity * 1000.0) as i64
         })
         .unwrap();
 
     let max_modularity = best_fitness_history
-            .iter()
-            .fold(None, |max, &val| match max {
+        .iter()
+        .fold(None, |max, &val| match max {
             None => Some(val),
             Some(max_val) if val > max_val && !val.is_nan() => Some(val),
             Some(max_val) => Some(max_val),
         });
 
-    (best_partition, best_fitness_history, max_modularity.unwrap())
+    (
+        best_partition,
+        best_fitness_history,
+        max_modularity.unwrap(),
+    )
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,6 +1,7 @@
 use rustc_hash::FxHashMap as HashMap;
 use rustc_hash::FxHashSet as HashSet;
 
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
@@ -8,7 +9,7 @@ use std::path::Path;
 
 pub type NodeId = i32;
 pub type CommunityId = i32;
-pub type Partition = HashMap<NodeId, CommunityId>;
+pub type Partition = BTreeMap<NodeId, CommunityId>;
 
 #[derive(Debug)]
 pub struct Graph {
@@ -59,11 +60,10 @@ impl Graph {
         Ok(graph)
     }
 
-    pub fn neighbors(&self, node: &NodeId) -> Vec<NodeId> {
+    pub fn neighbors(&self, node: &NodeId) -> &[NodeId] {
         self.adjacency_list
             .get(node)
-            .cloned()
-            .unwrap_or_default()
+            .map_or(&[], |x| x)
     }
 
     pub fn num_nodes(&self) -> usize {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,42 +1,46 @@
-
-use std::fs::{self};
-use std::path::Path;
 use serde_json;
 use std::env;
 use std::fs::exists;
+use std::fs::{self};
+use std::path::Path;
 use std::time::{Duration, Instant};
 
 use std::fs::OpenOptions;
 use std::io::Write;
 
-mod graph;
 mod algorithm;
+mod graph;
 
-use crate::graph::Graph;
 use crate::algorithm::genetic_algorithm;
+use crate::graph::Graph;
 
 const OUTPUT_PATH: &str = "src/graphs/output/output.json";
 const OUTPUT_CSV: &str = "src/graphs/output/mocd_output.csv";
 
-fn parse_args(args: &Vec<String>) -> (&str, bool) {
+fn parse_args(args: &Vec<String>) -> (&str, bool, bool) {
     if args.len() < 2 {
-        println!("Usage: <program> <file_path> [ -d for debug ]");
+        println!("Usage: <program> <file_path> [ -d for debug ] [ -s for serial processing ]");
         println!("Example: ./my_program ../graphs/artificial/karate.edgelist -d");
-        return ("", false);
+        return ("", false, false);
     }
 
     let file_path: &str = &args[1];
     if exists(file_path).is_err() {
         println!("Graph .edgelist file not found.");
-        return ("", false);
+        return ("", false, false);
     }
 
-    let debug_mode: bool = args.len() > 2 && &args[2] == "-d";
+    let debug_mode: bool = args.len() > 2 && args[2..].iter().any(|a| a == "-d");
     if debug_mode {
-        println!("[Warning] Debug mode: {} | This may increase algorithm time", debug_mode);
+        println!(
+            "[Warning] Debug mode: {} | This may increase algorithm time",
+            debug_mode
+        );
     }
 
-    (file_path, debug_mode)
+    let serial = args.len() > 2 && args[2..].iter().any(|a| a == "-s");
+
+    (file_path, debug_mode, !serial)
 }
 
 fn save_csv(time_taken: Instant, num_nodes: usize, num_edges: usize, modularity: f64) {
@@ -62,31 +66,26 @@ fn save_csv(time_taken: Instant, num_nodes: usize, num_edges: usize, modularity:
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();
-    
-    let (file_path, 
-        debug_mode
-    ) = parse_args(&args);
+
+    let (file_path, debug_mode, parallel) = parse_args(&args);
 
     let start: Instant = Instant::now();
     let graph = Graph::from_edgelist(Path::new(file_path))?;
     let reading_time: Duration = start.elapsed();
 
-    let (
-        best_partition,
-        _fitness_history,
-        modularity,
-    ) = genetic_algorithm(    
-        &graph, 
-        800, 
-        200,
-    debug_mode
-    );
+    let (best_partition, _fitness_history, modularity) =
+        genetic_algorithm(&graph, 800, 200, debug_mode, parallel);
 
     let json = serde_json::to_string_pretty(&best_partition)?;
     fs::write(OUTPUT_PATH, json)?;
-    println!("Algorithm time {:?} | Reading time: {:?} | Nodes: {:?} | Edges: {:?}", 
-    start.elapsed(), reading_time, graph.num_nodes(), graph.num_edges());
-    
+    println!(
+        "Algorithm time {:?} | Reading time: {:?} | Nodes: {:?} | Edges: {:?}",
+        start.elapsed(),
+        reading_time,
+        graph.num_nodes(),
+        graph.num_edges()
+    );
+
     save_csv(start, graph.num_nodes(), graph.num_edges(), modularity);
 
     Ok(())


### PR DESCRIPTION
Hi, I went over my changes on Reddit, and here's a PR for them.
- Everything's formatted according to `rustfmt`; I forgot that I had format on save enabled, sorry
- An unnecessary clone has been removed.
  - On iterators over IDs, `copied()` is used instead of `cloned()` so it's clearer that an expensive clone isn't taking place
- Hash set lookups for communities were taking a long time, so I replaced them with `Vec`s. Since they're being filled from a unique map, they're guaranteed to have unique elements themselves.
- The `Permutation` has been swapped to be a `BTreeMap`, which is sorted, which means that the community vectors are also sorted and can be binary searched rather than needing a linear search.
- Everything can run as either sequential or parallel, which was useful for my testing (profiling parallel code is awful, and rayon's plumbing was cluttering the output). It's still parallel by default, but passing `-s` forces it to run in a single thread.